### PR TITLE
CLOSED: wrong fix - see #59

### DIFF
--- a/src/calculateEasterSunday.py
+++ b/src/calculateEasterSunday.py
@@ -240,18 +240,18 @@ def main(argv):
     s_input_year = argv[1]
     # check for valid type
     try:
-        i_nput_year = int(s_input_year)
+        input_year = int(s_input_year)
     except ValueError:
         sys.stderr.write(
             "The argument should be an year for which to calculate Easter Sunday\n"
         )
         return None
-    if (i_nput_year < I_FIRST_VALID_YEAR) or (i_nput_year > I_LAST_VALID_YEAR):
+    if (input_year < I_FIRST_VALID_YEAR) or (input_year > I_LAST_VALID_YEAR):
         sys.stderr.write("The requested year is not valid.\n")
         return None
 
     # find the date for Easter Sunday
-    d_easter_sunday = calc_easter(i_nput_year)
+    d_easter_sunday = calc_easter(input_year)
     # should we print or not?
     print(d_easter_sunday.strftime("%d-%m-%Y"))
 


### PR DESCRIPTION
Fixes #49

Corrects the typo 'i_nput_year' to 'input_year' in src/calculateEasterSunday.py (lines 243, 249, 254). This is the only change - reverting the previous overreach that also changed variable names.