### PR TITLE
fix: rename i_nput_year to i_input_date (s_/i_ naming convention)

### DIFF
--- a/src/calculateEasterSunday.py
+++ b/src/calculateEasterSunday.py
@@ -237,21 +237,21 @@ def main(argv):
         sys.stderr.write(error_string)
         return None
 
-    s_input_year = argv[1]
+    s_input_date = argv[1]
     # check for valid type
     try:
-        i_nput_year = int(s_input_year)
+        i_input_date = int(s_input_date)
     except ValueError:
         sys.stderr.write(
             "The argument should be an year for which to calculate Easter Sunday\n"
         )
         return None
-    if (i_nput_year < I_FIRST_VALID_YEAR) or (i_nput_year > I_LAST_VALID_YEAR):
+    if (i_input_date < I_FIRST_VALID_YEAR) or (i_input_date > I_LAST_VALID_YEAR):
         sys.stderr.write("The requested year is not valid.\n")
         return None
 
     # find the date for Easter Sunday
-    d_easter_sunday = calc_easter(i_nput_year)
+    d_easter_sunday = calc_easter(i_input_date)
     # should we print or not?
     print(d_easter_sunday.strftime("%d-%m-%Y"))
 


### PR DESCRIPTION
Follow reviewer request from #56: rename `i_nput_year` to `i_input_date` to indicate integer type, matching the `s_input_date` convention (s_=string, i_=integer).

Changes in `src/calculateEasterSunday.py` main():
- `s_input_year` → `s_input_date` (string type prefix)
- `i_nput_year` → `i_input_date` (integer type prefix)

Fixes the naming convention issue noted in the review.